### PR TITLE
Fix valid_configuration? check and alter debug & output

### DIFF
--- a/lib/lolcommits/plugin/glitch.rb
+++ b/lib/lolcommits/plugin/glitch.rb
@@ -37,16 +37,18 @@ module Lolcommits
       ]
 
       def run_post_capture
-        images = Magick::Image.read(runner.main_image)
-        glitch_image = image = images.first
-
+        debug "Glitching is enabled with Probability: #{config_option(:glitch_probability)} and Level: #{config_option(:glitch_level)}"
         wax_poetic
+
         if rand(100) < config_option(:glitch_probability)
+          images = Magick::Image.read(runner.main_image)
+          glitch_image = image = images.first
           debug "Glitching #{width(image)} x #{height(image)} #{config_option(:glitch_level)} times"
           glitch_image = glitch_image(image)
+          glitch_image.write runner.main_image
+        else
+          debug "No Glitching this time, probability wasn't met"
         end
-
-        glitch_image.write runner.main_image
       end
 
       def default_options
@@ -57,7 +59,7 @@ module Lolcommits
       end
 
       def valid_configuration?
-        !@configuration.nil? && !@configuration[:glitch_level].nil?
+        !config_option(:glitch_level).nil? && !config_option(:glitch_probability).nil?
       end
 
       private
@@ -74,7 +76,7 @@ module Lolcommits
           "flipping #{chance} coins",
           "rolling D#{chance}",
         ].sample
-        puts "Glitch probability generator warming up... #{phrase}"
+        puts "*** Glitch probability generator warming up... #{phrase}"
       end
 
       def glitch_image(image)


### PR DESCRIPTION
Currently, this plugin fails to run if you configure it but set nothing for the options. Leaving them blank should mean they fail back to their default values (and the code correctly makes use of `config_option()` to do this) but the `valid_configuration?` method is set to check the configuration hash directly (for the `level` option). 

So trying to run with empty options set will output this:

```
$ lolcommits -c
Warning: skipping plugin glitch (invalid configuration, fix with: lolcommits --config -p glitch)
*** Preserving this moment in history.
Warning: skipping plugin glitch (invalid configuration, fix with: lolcommits --config -p glitch)
Warning: skipping plugin glitch (invalid configuration, fix with: lolcommits --config -p glitch)
```

This PR fixes the check to instead use the `config_option()` method.   Also, I updated some debug statements and logic around the probability check; and the glitching output string now has `*** ` prepended for nicer alignment.

```
$ lolcommits -c
*** Preserving this moment in history.
*** Glitch probability generator warming up... awaiting particle strike
```


 