### PR TITLE
Require lolcommits 0.14.2 as runtime dep, use lolcommit_path

### DIFF
--- a/lib/lolcommits/plugin/glitch.rb
+++ b/lib/lolcommits/plugin/glitch.rb
@@ -37,16 +37,20 @@ module Lolcommits
       ]
 
       def run_post_capture
-        images = Magick::Image.read(runner.main_image)
-        glitch_image = image = images.first
+        if runner.capture_image?
+          images = Magick::Image.read(runner.lolcommit_path)
+          glitch_image = image = images.first
 
-        wax_poetic
-        if rand(100) < config_option(:glitch_probability)
-          debug "Glitching #{width(image)} x #{height(image)} #{config_option(:glitch_level)} times"
-          glitch_image = glitch_image(image)
+          wax_poetic
+          if rand(100) < config_option(:glitch_probability)
+            debug "Glitching #{width(image)} x #{height(image)} #{config_option(:glitch_level)} times"
+            glitch_image = glitch_image(image)
+          end
+
+          glitch_image.write runner.lolcommit_path
+        else
+          debug "no image to glitch for a video or gif lolcommit"
         end
-
-        glitch_image.write runner.main_image
       end
 
       def default_options

--- a/lolcommits-glitch.gemspec
+++ b/lolcommits-glitch.gemspec
@@ -16,22 +16,14 @@ Gem::Specification.new do |spec|
   spec.license       = "LGPL-3.0"
 
   spec.metadata = {
-    "homepage_uri"    => "https://github.com/tooluser/lolcommits-glitch",
-    "changelog_uri"   => "https://github.com/tooluser/lolcommits-glitch/blob/master/CHANGELOG.md",
-    "source_code_uri" => "https://github.com/tooluser/lolcommits-glitch",
-    "bug_tracker_uri" => "https://github.com/tooluser/lolcommits-glitch/issues",
+    "homepage_uri"      => "https://github.com/tooluser/lolcommits-glitch",
+    "changelog_uri"     => "https://github.com/tooluser/lolcommits-glitch/blob/master/CHANGELOG.md",
+    "source_code_uri"   => "https://github.com/tooluser/lolcommits-glitch",
+    "bug_tracker_uri"   => "https://github.com/tooluser/lolcommits-glitch/issues",
+    "allowed_push_host" => "https://rubygems.org"
   }
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
- spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|features)/}) }
   spec.test_files    = `git ls-files -- {test,features}/*`.split("\n")
   spec.bindir        = "bin"
   spec.executables   = []
@@ -39,10 +31,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1"
 
-  spec.add_dependency "rmagick", "~> 3.0", ">= 3.0.0"
-  spec.add_dependency "faker", "~> 1.8", ">= 1.8.7"
+  spec.add_runtime_dependency "rmagick", "~> 3.0", ">= 3.0.0"
+  spec.add_runtime_dependency "faker", "~> 1.8", ">= 1.8.7"
+  spec.add_runtime_dependency "lolcommits", ">= 0.14.2"
+
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "lolcommits", "~> 0.12", ">= 0.12.0"
   spec.add_development_dependency "bundler", "~> 2.0", ">= 2.0.0"
   spec.add_development_dependency "rake", "~> 12.3", ">= 12.3.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Another small PR to make this plugin work with the latest version (0.14.2) of lolcommits, which now uses `lolcommit_path` instead of `main_image` for the captured and processed image file.

Since lolcommits can now generate video (and animated gif) captures, I've also added a check so the hook is skipped, unless we're capturing an image (checking `capture_image?`).

See [these](https://github.com/lolcommits/lolcommits/pull/392) [PRs](https://github.com/lolcommits/lolcommits/pull/386) and the [CHANGELOG](https://github.com/lolcommits/lolcommits/blob/master/CHANGELOG.md) for more info on lolcommits `v0.14+`